### PR TITLE
Minor typo fix for "GitHub" in index

### DIFF
--- a/client/app/bundles/App/components/PackageStats.jsx
+++ b/client/app/bundles/App/components/PackageStats.jsx
@@ -70,7 +70,7 @@ export default class PackageStats extends Component {
 		return(
 			<div className="package-stats">
 				{ this.state.githubStats && 
-					<h2>Github Stats</h2>
+					<h2>GitHub Stats</h2>
 				}
 				<PackageStatsTable githubStats={this.state.githubStats} />
 			</div>


### PR DESCRIPTION
The "H" thing is one of those "once you see it, you can't unsee".

Lovely site BTW, thanks, I chuckled when I saw it was a ruby app.