### PR TITLE
Use locale string for downloads (eg 1,000,000)

### DIFF
--- a/client/App/components/TrendGraph.jsx
+++ b/client/App/components/TrendGraph.jsx
@@ -58,8 +58,32 @@ export default class TrendGraph extends Component {
 				scaleFontColor: "#000000",
 				responsive: true,
 				datasetFill: false,
-				scaleLabel: "<%= ' ' + value%>",
 				maintainAspectRatio: false,
+				scales: {
+					yAxes: [
+						{
+							ticks: {
+								beginAtZero: true,
+								userCallback: (value, index, values) => {
+									return Number(value).toLocaleString();
+								}
+							}
+						}
+					],
+					xAxes: [
+						{
+							ticks: {}
+						}
+					]
+				},
+				tooltips: {
+					callbacks: {
+						label: (tooltipItem, data) => {
+							const value = data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index];
+							return Number(value).toLocaleString();
+						}
+					}
+				},
 			}
 			var ctx = document.getElementById("download_chart").getContext("2d");
 			this.download_chart = new Chart(ctx, {
@@ -81,8 +105,4 @@ export default class TrendGraph extends Component {
 	}
 
 };
-
-
-
-
 


### PR DESCRIPTION
All those big numbers are a bit hard to read without separators, so I've customised the Chart.js config to use [`Number.toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) to format the download count in the Y axis and the tool-tips.

I have road-tested the Chart.js callbacks (https://codesandbox.io/s/confident-payne-nrrhr) but I'm not set up with Redis and npm-trends-proxy so I haven't been able to test the integration.